### PR TITLE
fix: Ensure minimal .bashrc_user exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 $ bash migrate_home.sh
 ```
 
-2. In your `/raid/projects/$USER/.bash_profile` add the following comment anywhere **above** sourcing of `~/.bashrc` to set the start location for adding `pyenv` information to your `.bash_profile`
+2. In your `/raid/projects/$USER/.bash_profile` make sure that the following comment exists anywhere **above** the sourcing of `~/.bashrc` to set the start location for adding `pyenv` information to your `.bash_profile`
 
 ```bash
 # pyenv setup

--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -24,6 +24,15 @@ ln --symbolic --force $(readlink -f "${RAID_HOME}/.bash_aliases") $(readlink -f 
 touch "${RAID_HOME}/.bashrc_user"
 ln --symbolic --force $(readlink -f "${RAID_HOME}/.bashrc_user") $(readlink -f "${DEFAULT_HOME}/.bashrc_user")
 
+# Ensure minimal required .bashrc_user
+if [ ! "$(sed -n '/^#!/p;q' ${RAID_HOME}/.bashrc_user)" ]; then
+    # If no shebang assume zero-sized (empty) file
+    echo '#!/usr/bin/env bash' > "${RAID_HOME}/.bashrc_user"
+	# Ensure the shebang '#!/usr/bin/env bash'
+	elif [ ! "$(sed -n '/^#!\/usr\/bin\/env bash/p;q' ${RAID_HOME}/.bashrc_user)" ]; then
+	    sed -i "1s/.*/#!\/usr\/bin\/env bash/" "${RAID_HOME}/.bashrc_user"
+fi
+
 # Also get .Xauthority
 cp "${DEFAULT_HOME}/.Xauthority" .
 ln --symbolic --force $(readlink -f "${RAID_HOME}/.Xauthority") $(readlink -f "${DEFAULT_HOME}/.Xauthority")

--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -56,5 +56,8 @@ sed -i '/^# .bash_profile*/a export HOME="/raid/projects/${USER}"' "${RAID_HOME}
 printf '\n# User specific aliases and functions\nif [ -f ~/.bash_aliases ]; then\n    . ~/.bash_aliases\nfi\n' >> "${RAID_HOME}/.bashrc"
 printf "\n# Instead of directly editing the system's default .bashrc load a user version\nif [ -f ~/.bashrc_user ]; then\n    . ~/.bashrc_user\nfi\n" >> "${RAID_HOME}/.bashrc"
 
+# Inject `# pyenv setup` before sourcing .bashrc (and so .bashrc_user) for use in pyenv_setup.sh
+sed -i "$(($(grep -n 'f ~/.bashrc ];' ${RAID_HOME}/.bash_profile | cut -f1 -d:) - 1))"' i # pyenv setup\n' "${RAID_HOME}/.bash_profile"
+
 unset DEFAULT_HOME
 unset RAID_HOME

--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -25,12 +25,17 @@ touch "${RAID_HOME}/.bashrc_user"
 ln --symbolic --force $(readlink -f "${RAID_HOME}/.bashrc_user") $(readlink -f "${DEFAULT_HOME}/.bashrc_user")
 
 # Ensure minimal required .bashrc_user
+# * Ensure desired shebang
 if [ ! "$(sed -n '/^#!/p;q' ${RAID_HOME}/.bashrc_user)" ]; then
     # If no shebang assume zero-sized (empty) file
     echo '#!/usr/bin/env bash' > "${RAID_HOME}/.bashrc_user"
 	# Ensure the shebang '#!/usr/bin/env bash'
 	elif [ ! "$(sed -n '/^#!\/usr\/bin\/env bash/p;q' ${RAID_HOME}/.bashrc_user)" ]; then
 	    sed -i "1s/.*/#!\/usr\/bin\/env bash/" "${RAID_HOME}/.bashrc_user"
+fi
+# * Ensure exporting of HOME
+if ! grep -q 'export HOME="/raid/projects/${USER}"' "${RAID_HOME}/.bashrc_user"; then
+   printf '\nexport HOME="/raid/projects/${USER}"\n' >> "${RAID_HOME}/.bashrc_user"
 fi
 
 # Also get .Xauthority

--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -37,6 +37,10 @@ fi
 if ! grep -q 'export HOME="/raid/projects/${USER}"' "${RAID_HOME}/.bashrc_user"; then
    printf '\nexport HOME="/raid/projects/${USER}"\n' >> "${RAID_HOME}/.bashrc_user"
 fi
+# * Inject `cd $HOME` after the sourcing of .bashrc (and so .bashrc_user)
+sed -i "$(($(grep -n 'f ~/.bashrc ];' ${RAID_HOME}/.bash_profile | cut -f1 -d:) + 4))"' i # .bashrc_user sets $HOME to another location than default' "${RAID_HOME}/.bash_profile"
+sed -i "$(($(grep -n 'f ~/.bashrc ];' ${RAID_HOME}/.bash_profile | cut -f1 -d:) + 5))"' i cd "${HOME}"\n' "${RAID_HOME}/.bash_profile"
+
 
 # Also get .Xauthority
 cp "${DEFAULT_HOME}/.Xauthority" .

--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -3,6 +3,11 @@
 export DEFAULT_HOME="/home/${USER}"
 export RAID_HOME="/raid/projects/${USER}"
 
+# Make restore files of system defaults
+cp "${DEFAULT_HOME}/.bash_profile" "${DEFAULT_HOME}/.bash_profile.bak"
+cp "${DEFAULT_HOME}/.bashrc" "${DEFAULT_HOME}/.bashrc.bak"
+cp "${DEFAULT_HOME}/.bash_logout" "${DEFAULT_HOME}/.bash_logout.bak"
+
 mkdir -p "${RAID_HOME}"
 cd "${RAID_HOME}"
 


### PR DESCRIPTION
Resolves #4

```
* Create restore .bak files of the system default .bash dotfiles
* In migrate_home.sh ensure that the minimal required .bashrc_user and make one for the user if it doesn't
* Inject the required `# pyenv setup` comment for pyenv_setup.sh and note this in instructions 
```