### PR TITLE
fix: Correct direction of .Xauthority symlink

### DIFF
--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -44,7 +44,7 @@ sed -i "$(($(grep -n 'f ~/.bashrc ];' ${RAID_HOME}/.bash_profile | cut -f1 -d:) 
 
 # Also get .Xauthority
 cp "${DEFAULT_HOME}/.Xauthority" .
-ln --symbolic --force $(readlink -f "${RAID_HOME}/.Xauthority") $(readlink -f "${DEFAULT_HOME}/.Xauthority")
+ln --symbolic --force $(readlink -f "${DEFAULT_HOME}/.Xauthority") $(readlink -f "${RAID_HOME}/.Xauthority")
 
 # symlink .ssh info from default home to home on /raid
 ln --symbolic $(readlink -f "${DEFAULT_HOME}/.ssh") $(readlink -f "${RAID_HOME}")/.ssh

--- a/migrate_home.sh
+++ b/migrate_home.sh
@@ -42,8 +42,7 @@ sed -i "$(($(grep -n 'f ~/.bashrc ];' ${RAID_HOME}/.bash_profile | cut -f1 -d:) 
 sed -i "$(($(grep -n 'f ~/.bashrc ];' ${RAID_HOME}/.bash_profile | cut -f1 -d:) + 5))"' i cd "${HOME}"\n' "${RAID_HOME}/.bash_profile"
 
 
-# Also get .Xauthority
-cp "${DEFAULT_HOME}/.Xauthority" .
+# symlink .Xauthority from default home to home on /raid
 ln --symbolic --force $(readlink -f "${DEFAULT_HOME}/.Xauthority") $(readlink -f "${RAID_HOME}/.Xauthority")
 
 # symlink .ssh info from default home to home on /raid


### PR DESCRIPTION
`/home/$USER/.Xauthority` is not stable and can be overwritten. This breaks the symlink if going from `/raid/projects/$USER` to `/home/$USER` so link from `/home/$USER` to `/raid/projects/$USER`

```
* Flip direction of .Xauthority symlink to be `/home/$USER/.Xauthority` to `/raid/projects/$USER/.Xauthority`
   - `/home/$USER/.Xauthority` is not stable and can be overwritten breaking the symlink if the other direction
```

cc @msneubauer 