### PR TITLE
fix: Avoid matplotlib.pyplot API in test example to avoid GUI slowdown

### DIFF
--- a/test/example.py
+++ b/test/example.py
@@ -5,7 +5,8 @@ if __name__ == "__main__":
     x = np.linspace(0, 10, 1000)
     y = np.sin(x)
 
-    fig, ax = plt.subplots()
+    fig = Figure()
+    ax = fig.subplots()
     ax.plot(x, y)
 
     ax.set_xlabel(r"$x$")

--- a/test/example.py
+++ b/test/example.py
@@ -1,5 +1,5 @@
-import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.figure import Figure
 
 if __name__ == "__main__":
     x = np.linspace(0, 10, 1000)


### PR DESCRIPTION
Use of the `matplotlib.pyplot` API will allocate a GUI, which slows down plotting if `X11` forwarding is available as it ensures that it has the ability to open a window. To avoid this, use the `matplotlib.figure` API to avoid the GUI

```
* Use matplotlib.figure API over matplotlib.pyplot API in test example
   - Avoids slowdown due to GUI and X11 interaction
   - c.f. https://gist.github.com/matthewfeickert/84245837f09673b2e7afea929c016904
```