### PR TITLE
fix: Ensure Conda and pyenv environments don't clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,31 @@ MLFlow [works best with Conda for managing environments](https://www.mlflow.org/
 `pyenv` has the ability to install Conda distributions as well, so you can just `pyenv install` whatever distribution you'd like (c.f. output of `pyenv install --list | grep conda`)
 
 ```console
-# Example
 $ pyenv install miniconda3-latest
 ```
 
-You can now just treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.
+You can now
+
+```console
+$ pyenv shell miniconda3-latest
+$ conda init
+$ conda config --set auto_activate_base false
+```
+
+and after a shell restart you can treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.
+
+```console
+$ pyenv virtualenv miniconda3-latest mlflow-base
+```
+
+This environment can now be activated with either `pyenv activate` or `conda activate`.
+
+
+Note that it is important to make sure the `auto_activate_base false` command is run &mdash; which results in the following being added to your `.condarc`
+
+```console
+$ grep auto_activate ~/.condarc
+auto_activate_base: false
+```
+
+&mdash; to ensure that there won't be conflict between Conda environment Python runtimes and any other virtual environment that you have.

--- a/README.md
+++ b/README.md
@@ -61,13 +61,21 @@ which should produce a plot named `mpl_example.png` in your current working dire
 ## Optional Conda Install for MLFlow
 
 MLFlow [works best with Conda for managing environments](https://www.mlflow.org/docs/latest/projects.html#mlproject-file).
-`pyenv` has the ability to install Conda distributions as well, so you can just `pyenv install` whatever distribution you'd like (c.f. output of `pyenv install --list | grep conda`)
+`pyenv` has the ability to install Conda distributions as well, so you can `pyenv install` whatever distribution you'd like (c.f. output of `pyenv install --list | grep conda`)
 
 ```console
 $ pyenv install miniconda3-latest
 ```
 
-You can now
+You can treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.
+
+```console
+$ pyenv virtualenv miniconda3-latest mlflow-base
+```
+
+### Making Conda useable standalone
+
+If you want to be able to use Conda for package management directly outside of `pyenv`, you just need to use the install miniconda distribution to initialize Conda
 
 ```console
 $ pyenv shell miniconda3-latest
@@ -75,13 +83,7 @@ $ conda init
 $ conda config --set auto_activate_base false
 ```
 
-and after a shell restart you can treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.
-
-```console
-$ pyenv virtualenv miniconda3-latest mlflow-base
-```
-
-This environment can now be activated with either `pyenv activate` or `conda activate`.
+and after a shell restart your Conda `pyenv` environments can now be activated with either `pyenv activate` or `conda activate`.
 
 
 Note that it is important to make sure the `auto_activate_base false` command is run &mdash; which results in the following being added to your `.condarc`
@@ -92,3 +94,4 @@ auto_activate_base: false
 ```
 
 &mdash; to ensure that there won't be conflict between Conda environment Python runtimes and any other virtual environment that you have.
+As `conda init` will still place `condabin` onto `PATH` you will not need to update [MLFlow's `MLFLOW_CONDA_HOME` shell variable](https://www.mlflow.org/docs/latest/projects.html#project-environments).

--- a/README.md
+++ b/README.md
@@ -59,17 +59,13 @@ $ pyenv activate base
 which should produce a plot named `mpl_example.png` in your current working directory.
 
 ## Optional Conda Install for MLFlow
-MLFlow works best with conda. To install it:
 
-* Download a copy of the miniconda install script
+MLFlow [works best with Conda for managing environments](https://www.mlflow.org/docs/latest/projects.html#mlproject-file).
+`pyenv` has the ability to install Conda distributions as well, so you can just `pyenv install` whatever distribution you'd like (c.f. output of `pyenv install --list | grep conda`)
+
 ```console
-$ wget https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh
+# Example
+$ pyenv install miniconda3-latest
 ```
 
-* Execute the install script
-```console
-$ bash Miniconda3-py38_4.10.3-Linux-x86_64.sh
-```
-
-* Accept the license terms
-* Accept the defaults and allow it to run `conda init`
+You can now just treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ pyenv virtualenv miniconda3-latest mlflow-base
 
 ### Making Conda useable standalone
 
-If you want to be able to use Conda for package management directly outside of `pyenv`, you just need to use the install miniconda distribution to initialize Conda
+If you want to be able to use Conda for package management directly outside of `pyenv`, you just need to use the installed miniconda distribution to initialize Conda
 
 ```console
 $ pyenv shell miniconda3-latest


### PR DESCRIPTION
As described in https://github.com/Neubauer-Group/dgx-setup/pull/9#issuecomment-900015317, the default installation of a miniconda distribution can result in conflicts between Conda and other virtual environments. To avoid this, set `auto_activate_base` to `false` in the user's `~/.condarc` and advocate for installation using `pyenv`.

```
* Install miniconda distribution with pyenv
   - Mention that `conda init` is only needed to use conda for package management outside of pyenv, as MLFlow's default operation uses
   - c.f. https://www.mlflow.org/docs/latest/projects.html#project-environments
* Set auto_activate_base to false in .condarc to avoid conflicts between Conda environments and other Python virtual environments
```