### PR TITLE
fix: Clarify need for `conda init` to use Conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ You can treat the miniconda version that you've selected as you would any other 
 $ pyenv virtualenv miniconda3-latest mlflow-base
 ```
 
-### Making Conda useable standalone
-
-If you want to be able to use Conda for package management directly outside of `pyenv`, you just need to use the installed miniconda distribution to initialize Conda
+To be able to use Conda for package management with or without `pyenv`, you just need to use the installed miniconda distribution to initialize Conda
 
 ```console
 $ pyenv shell miniconda3-latest

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can treat the miniconda version that you've selected as you would any other 
 $ pyenv virtualenv miniconda3-latest mlflow-base
 ```
 
-These Conda `pyenv` environments can be activated with either `pyenv activate` or `conda activate`.
+These Conda `pyenv` environments can be activated with either `pyenv activate` or `conda activate`, though it is recommended to **only** use `pyenv activate` as switching between `pyenv` environments with a `conda` environment activated will not update the Python runtime used.
 
 Note that it is important to make sure the `auto_activate_base false` command is run &mdash; which results in the following being added to your `.condarc`
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,7 @@ MLFlow [works best with Conda for managing environments](https://www.mlflow.org/
 $ pyenv install miniconda3-latest
 ```
 
-You can treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.
-
-```console
-$ pyenv virtualenv miniconda3-latest mlflow-base
-```
-
-To be able to use Conda for package management with or without `pyenv`, you just need to use the installed miniconda distribution to initialize Conda
+To be able to use Conda for package management with or without `pyenv`, use the installed miniconda distribution to initialize Conda
 
 ```console
 $ pyenv shell miniconda3-latest
@@ -81,8 +75,15 @@ $ conda init
 $ conda config --set auto_activate_base false
 ```
 
-and after a shell restart your Conda `pyenv` environments can now be activated with either `pyenv activate` or `conda activate`.
+and after a shell restart `conda` will now be found and useable.
 
+You can treat the miniconda version that you've selected as you would any other `pyenv` version when creating a `pyenv` virtual environment.
+
+```console
+$ pyenv virtualenv miniconda3-latest mlflow-base
+```
+
+These Conda `pyenv` environments can be activated with either `pyenv activate` or `conda activate`.
 
 Note that it is important to make sure the `auto_activate_base false` command is run &mdash; which results in the following being added to your `.condarc`
 


### PR DESCRIPTION
```
* Clarify the need to have run `conda init` to be able to use Conda commands at all
* Advocate for only ever using `pyenv activate` with Conda pyenv virtual environments
   - If you run `conda activate env-A` and then `pyenv activate env-B`, env-A will not properly get switched out of
```